### PR TITLE
Fix upstream Whyis integration test issues

### DIFF
--- a/load-data.sh
+++ b/load-data.sh
@@ -7,7 +7,7 @@ if [ -d "venv" ]; then
 fi
 
 # Create a demo user
-python3 manage.py createuser -e whyis@whyis.com -p whyis --roles=admin
+python3 manage.py createuser -e whyis@whyis.com -u whyis -p whyis --roles=admin
 
 # Load the SETL'd ArrayExpress data
 python3 manage.py load -i /apps/whyis-demo/data/ae_experiments.ttl -f turtle --temp-store IOMemory


### PR DESCRIPTION
Because of some recent changes to how the Whyis command line
interface works, specifying a username when creating a user is required.

This caused the user creation to fail in load_data.sh, so running login
integration tests on Whyis would not work.